### PR TITLE
Fixed check for installed XD roles

### DIFF
--- a/DSCResources/XD7Common/XD7Common.psm1
+++ b/DSCResources/XD7Common/XD7Common.psm1
@@ -343,7 +343,7 @@ function GetXDInstalledRole {
         [Parameter(Mandatory)] [ValidateSet('Controller','Studio','Storefront','Licensing','Director','DesktopVDA','SessionVDA')] [System.String] $Role
     )
     process {
-        $installedProducts = Get-ItemProperty 'HKLM:\SOFTWARE\Classes\Installer\Products\*' |
+        $installedProducts = Get-ItemProperty 'HKLM:\SOFTWARE\Classes\Installer\Products\*' -ErrorAction SilentlyContinue |
             Where-Object { $_.ProductName -like '*Citrix*' -and $_.ProductName -notlike '*snap-in' } |
                 Select-Object -ExpandProperty ProductName;
         switch ($Role) {


### PR DESCRIPTION
The check now works even if the key named Products is not present
