### PR TITLE
XD7Controller: Test-TargetResource - Error message "Cannot validate argument on parameter 'AdminAddress'. The argument is null."

### DIFF
--- a/DSCResources/VE_XD7Common/VE_XD7Common.psm1
+++ b/DSCResources/VE_XD7Common/VE_XD7Common.psm1
@@ -1,4 +1,4 @@
-Import-LocalizedData -BindingVariable localized -FileName VE_XD7Common.Resources.psd1;
+﻿Import-LocalizedData -BindingVariable localized -FileName VE_XD7Common.Resources.psd1;
 
 #region Private Functions
 
@@ -548,7 +548,7 @@ function GetXDInstalledRole {
                     $filter = 'Citrix Studio';
                 }
                 'Storefront' {
-                    $filter = 'Citrix Storefront';
+                    $filter = 'Citrix Storefront$';
                 }
                 'Licensing' {
                     $filter = 'Citrix Licensing';

--- a/DSCResources/VE_XD7Controller/VE_XD7Controller.psm1
+++ b/DSCResources/VE_XD7Controller/VE_XD7Controller.psm1
@@ -181,13 +181,13 @@ function Set-TargetResource {
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            ## Override the local computer name returned by AddInvokeScriptBlockCredentials with the existing XenDesktop controller address
+            $invokeCommandParams['ComputerName'] = $ExistingControllerName;
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
         }
 
-        ## Override the local computer name returned by AddInvokeScriptBlockCredentials with the existing XenDesktop controller address
-        $invokeCommandParams['ComputerName'] = $ExistingControllerName;
         $scriptBlockParams = @($ExistingControllerName, $localHostName, $Ensure, $Credential)
         Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", $scriptBlockParams));
 

--- a/DSCResources/VE_XD7Controller/VE_XD7Controller.psm1
+++ b/DSCResources/VE_XD7Controller/VE_XD7Controller.psm1
@@ -1,4 +1,4 @@
-Import-LocalizedData -BindingVariable localizedData -FileName VE_XD7Controller.Resources.psd1;
+﻿Import-LocalizedData -BindingVariable localizedData -FileName VE_XD7Controller.Resources.psd1;
 
 function Get-TargetResource {
     [CmdletBinding()]
@@ -56,13 +56,13 @@ function Get-TargetResource {
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            ## Overwrite the local ComputerName returned by AddInvokeScriptBlockCredentials
+            $invokeCommandParams['ComputerName'] = $ExistingControllerName;
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
         }
 
-        ## Overwrite the local ComputerName returned by AddInvokeScriptBlockCredentials
-        $invokeCommandParams['ComputerName'] = $ExistingControllerName;
         Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($ExistingControllerName)));
 
         return Invoke-Command @invokeCommandParams;


### PR DESCRIPTION
When using XD7Controller without `Credential` parameter, Test-TargetResource does not succeed running `Get-XDSite` with the following error returned by `Invoke-Command @invokeCommandParams`

```
Cannot validate argument on parameter 'AdminAddress'. The argument is null. Provide a valid value for the argument, and then try running the command again.
```

As far as I can tell this is because the `ComputerName` parameter gets added to the `invokeCommandParams` hashtable with the value of `$ExistingController` which then results in `Invoke-Command` opening a PSRemotingSession (successfully in my case I guess) to the `$ExistingController` computer and as part of this the variable value `$ExistingController` ends up being undefined/null in the remote session. This then results in `Get-XDSite -AdminAddress` being called in the Remoting session with `$null` being the value passed as the parameter to `-AdminAddress`

Now, I don't use the `Credential` functionality in any of the XenDesktop7 resources since the built-in `PsRunAsCredential` in DSC works just fine for me.

But by simply looking at the code in question, I think there is a simple flaw where the following code should be moved inside of the preceding if-block:

https://github.com/VirtualEngine/XenDesktop7/blob/1f96d97b1fc31d453c0aa9f08e6c687a78ad512a/DSCResources/VE_XD7Controller/VE_XD7Controller.psm1#L64-L65