### PR TITLE
Fix TestXDSite to make XD7WaitForSite run with psdscrunascredential

### DIFF
--- a/DSCResources/VE_XD7WaitForSite/VE_XD7WaitForSite.psm1
+++ b/DSCResources/VE_XD7WaitForSite/VE_XD7WaitForSite.psm1
@@ -196,7 +196,7 @@ function TestXDSite {
         }
         else {
 
-            $scriptBlock = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
+            $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
         }
 
         Write-Verbose $localizedData.InvokingScriptBlock;


### PR DESCRIPTION
Additional fix needed to make XD7WaitForSite run with **psdscrunascredential**.

Without this fix to the **TestXDSite** function, the following error is triggered by the Get-XDSite but masked to the user by the try/catch routine.

```
A Using variable cannot be retrieved. A Using variable can be used only with Invoke-Command, Start-Job, or InlineScript in 
the script workflow. When it is used with Invoke-Command, the Using variable is valid only if the script block is invoked 
on a remote computer.
At C:\Users\Administrator.DOMAIN-TEST\Documents\TestXDSite.ps1:27 char:17
+ ...             $xdSite = Get-XDSite -AdminAddress $using:ExistingControl ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : UsingWithoutInvokeCommand
```
