### PR TITLE
More compatible with psdscrunascredential

### DIFF
--- a/DSCResources/VE_XD7Administrator/VE_XD7Administrator.psm1
+++ b/DSCResources/VE_XD7Administrator/VE_XD7Administrator.psm1
@@ -57,11 +57,11 @@ function Get-TargetResource {
             ErrorAction = 'Stop';
         }
 
+        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name, $Enabled, $Ensure)));
+
         if ($Credential) {
-            AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
-            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name, $Enabled, $Ensure)));
-            $targetResource = Invoke-Command  @invokeCommandParams;
-            
+            AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;            
+            $targetResource = Invoke-Command  @invokeCommandParams;            
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
@@ -187,15 +187,15 @@ function Set-TargetResource {
                 }
             }
         } #end scriptblock
-
         $invokeCommandParams = @{
             ScriptBlock = $scriptBlock;
             ErrorAction = 'Stop';
         }
 
+        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name, $Enabled, $Ensure)));
+
         if ($Credential) {
-            AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
-            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name, $Enabled, $Ensure)));
+            AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;            
             [ref] $null = Invoke-Command @invokeCommandParams;
         }
         else {

--- a/DSCResources/VE_XD7Administrator/VE_XD7Administrator.psm1
+++ b/DSCResources/VE_XD7Administrator/VE_XD7Administrator.psm1
@@ -59,13 +59,14 @@ function Get-TargetResource {
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name, $Enabled, $Ensure)));
+            $targetResource = Invoke-Command  @invokeCommandParams;
+            
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
+            $targetResource = & $invokeCommandParams.ScriptBlock;
         }
-
-        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name, $Enabled, $Ensure)));
-        $targetResource = Invoke-Command  @invokeCommandParams;
 
         return $targetResource;
 
@@ -194,14 +195,13 @@ function Set-TargetResource {
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name, $Enabled, $Ensure)));
+            [ref] $null = Invoke-Command @invokeCommandParams;
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
-        }
-
-        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name, $Enabled, $Ensure)));
-
-        [ref] $null = Invoke-Command @invokeCommandParams;
+            [ref] $null = & $invokeCommandParams.ScriptBlock
+        }        
 
     } #end process
 } #end function Set-TargetResource

--- a/DSCResources/VE_XD7Catalog/VE_XD7Catalog.psm1
+++ b/DSCResources/VE_XD7Catalog/VE_XD7Catalog.psm1
@@ -93,14 +93,13 @@ function Get-TargetResource {
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name)));
+            return Invoke-Command @invokeCommandParams;
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
+            return & $invokeCommandParams.ScriptBlock
         }
-
-        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name)));
-
-        return Invoke-Command @invokeCommandParams;
 
     } #end process
 } #end function Get-TargetResource
@@ -353,15 +352,16 @@ function Set-TargetResource {
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            $scriptBlockParams = @($Name, $Ensure, $Allocation, $Provisioning, $Persistence, $IsMultiSession, $Description, $PvsAddress, $PvsDomain);
+            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", $scriptBlockParams));    
+            [ref] $null = Invoke-Command @invokeCommandParams;
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
+            [ref] $null = & $invokeCommandParams.ScriptBlock
         }
 
-        $scriptBlockParams = @($Name, $Ensure, $Allocation, $Provisioning, $Persistence, $IsMultiSession, $Description, $PvsAddress, $PvsDomain);
-        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", $scriptBlockParams));
-
-        [ref] $null = Invoke-Command @invokeCommandParams;
+        
 
     } #end process
 } #end function Set-TargetResource

--- a/DSCResources/VE_XD7CatalogMachine/VE_XD7CatalogMachine.psm1
+++ b/DSCResources/VE_XD7CatalogMachine/VE_XD7CatalogMachine.psm1
@@ -51,14 +51,16 @@ function Get-TargetResource {
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name)));
+            return Invoke-Command  @invokeCommandParams;
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
+            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name)));
+            & $scriptblock['ScriptBlock']
         }
 
-        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name)));
-
-        return Invoke-Command  @invokeCommandParams;
+        
 
     } #end process
 } #end function Get-TargetResource
@@ -167,15 +169,13 @@ function Set-TargetResource {
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name, $Members, $Ensure)));
+            [ref] $null = Invoke-Command @invokeCommandParams;
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
+            & $invokeCommandParams['ScriptBlock']
         }
-
-        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name, $Members, $Ensure)));
-
-        [ref] $null = Invoke-Command @invokeCommandParams;
-
     } #end process
 } #end function Set-TargetResource
 

--- a/DSCResources/VE_XD7CatalogMachine/VE_XD7CatalogMachine.psm1
+++ b/DSCResources/VE_XD7CatalogMachine/VE_XD7CatalogMachine.psm1
@@ -57,7 +57,7 @@ function Get-TargetResource {
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
             Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", @($Name)));
-            & $scriptblock['ScriptBlock']
+            return & $invokeCommandParams.ScriptBlock
         }
 
         
@@ -174,7 +174,7 @@ function Set-TargetResource {
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
-            & $invokeCommandParams['ScriptBlock']
+            return & $invokeCommandParams.ScriptBlock
         }
     } #end process
 } #end function Set-TargetResource

--- a/DSCResources/VE_XD7Controller/VE_XD7Controller.psm1
+++ b/DSCResources/VE_XD7Controller/VE_XD7Controller.psm1
@@ -178,8 +178,8 @@ function Set-TargetResource {
             ErrorAction = 'Stop';
         }
 
-        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", $scriptBlockParams));
-        $scriptBlockParams = @($ExistingControllerName, $localHostName, $Ensure, $Credential)    
+        $scriptBlockParams = @($ExistingControllerName, $localHostName, $Ensure, $Credential)
+        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", $scriptBlockParams));         
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;

--- a/DSCResources/VE_XD7Controller/VE_XD7Controller.psm1
+++ b/DSCResources/VE_XD7Controller/VE_XD7Controller.psm1
@@ -40,7 +40,7 @@ function Get-TargetResource {
                 ExistingControllerName = $using:ExistingControllerName;
                 Ensure = 'Absent';
             }
-            if (($xdSite.Name -eq $SiteName) -and ($xdSite.Controllers.DnsName -contains $localHostName)) {
+            if (($xdSite.Name -eq $using:SiteName) -and ($xdSite.Controllers.DnsName -contains $using:localHostName)) {
                 $targetResource['Ensure'] = 'Present';
             }
             return $targetResource;

--- a/DSCResources/VE_XD7Role/VE_XD7Role.psm1
+++ b/DSCResources/VE_XD7Role/VE_XD7Role.psm1
@@ -60,14 +60,14 @@ function Get-TargetResource {
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            $scriptBlockParams = @($Name, $RoleScope, $Members, $Ensure);
+            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", $scriptBlockParams));
+            $targetResource = Invoke-Command  @invokeCommandParams;
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
+            $targetResource = & $invokeCommandParams.ScriptBlock
         }
-
-        $scriptBlockParams = @($Name, $RoleScope, $Members, $Ensure);
-        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", $scriptBlockParams));
-        $targetResource = Invoke-Command  @invokeCommandParams;
 
         return $targetResource;
 
@@ -228,15 +228,14 @@ function Set-TargetResource {
 
         if ($Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            $scriptBlockParams = @($Name, $RoleScope, $Members, $Ensure);
+            Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", $scriptBlockParams));
+            [ref] $null = Invoke-Command  @invokeCommandParams;
         }
         else {
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
+            [ref] $null = & $invokeCommandParams.ScriptBlock
         }
-
-        $scriptBlockParams = @($Name, $RoleScope, $Members, $Ensure);
-        Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", $scriptBlockParams));
-
-        [ref] $null = Invoke-Command  @invokeCommandParams;
 
     } #end process
 } #end function Set-TargetResource

--- a/DSCResources/VE_XD7SiteLicense/VE_XD7SiteLicense.psm1
+++ b/DSCResources/VE_XD7SiteLicense/VE_XD7SiteLicense.psm1
@@ -62,12 +62,12 @@ function Get-TargetResource {
                 LicenseEdition = $xdSiteConfig.ProductEdition;
                 LicenseModel = $xdSiteConfig.LicensingModel;
                 TrustLicenseServerCertificate = !([System.String]::IsNullOrEmpty($xdSiteConfig.MetaDataMap.CertificateHash));
-                Ensure = $using:Ensure;
+                Ensure = $Ensure;
             };
 
             return $targetResource;
         } #end scriptblock
-
+        <# 
         $invokeCommandParams = @{
             ScriptBlock = $scriptBlock;
             ErrorAction = 'Stop';
@@ -82,8 +82,8 @@ function Get-TargetResource {
 
         $scriptBlockParams = @($LicenseServer, $LicenseServerPort, $LicenseEdition, $LicenseModel);
         Write-Verbose ($localizedData.InvokingScriptBlockWithParams -f [System.String]::Join("','", $scriptBlockParams));
-
-        return Invoke-Command @invokeCommandParams;
+        #>
+        & $scriptblock;
 
     } #end process
 } #end function Get-TargetResource

--- a/DSCResources/VE_XD7WaitForSite/VE_XD7WaitForSite.psm1
+++ b/DSCResources/VE_XD7WaitForSite/VE_XD7WaitForSite.psm1
@@ -188,8 +188,7 @@ function TestXDSite {
             ScriptBlock = $scriptBlock;
             ErrorAction = 'Stop';
         }
-        ##Removed because we do not need CredSSP authentication in v5.
-        <#
+                
         if ($null -ne $Credential) {
 
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
@@ -198,7 +197,7 @@ function TestXDSite {
 
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
         }
-        #>
+        
         Write-Verbose $localizedData.InvokingScriptBlock;
 
         & $scriptBlock

--- a/DSCResources/VE_XD7WaitForSite/VE_XD7WaitForSite.psm1
+++ b/DSCResources/VE_XD7WaitForSite/VE_XD7WaitForSite.psm1
@@ -190,17 +190,18 @@ function TestXDSite {
             ErrorAction = 'Stop';
         }
 
+        Write-Verbose $localizedData.InvokingScriptBlock;
+
         if ($null -ne $Credential) {
-            AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
-            Write-Verbose $localizedData.InvokingScriptBlock;
+
+            AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;            
             return Invoke-Command @invokeCommandParams;
         }
         else {
-            $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
-            Write-Verbose $localizedData.InvokingScriptBlock;
+            
+            $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));            
             return & $invokeCommandParams.ScriptBlock
-        }
-        
+        }        
     } #end process
 } #end function TestXDSite
 

--- a/DSCResources/VE_XD7WaitForSite/VE_XD7WaitForSite.psm1
+++ b/DSCResources/VE_XD7WaitForSite/VE_XD7WaitForSite.psm1
@@ -1,5 +1,4 @@
 Import-LocalizedData -BindingVariable localizedData -FileName VE_XD7WaitForSite.Resources.psd1;
-
 function Get-TargetResource {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
@@ -177,7 +176,7 @@ function TestXDSite {
             Import-Module 'C:\Program Files\Citrix\XenDesktopPoshSdk\Module\Citrix.XenDesktop.Admin.V1\Citrix.XenDesktop.Admin\Citrix.XenDesktop.Admin.psd1';
             try {
 
-                $xdSite = Get-XDSite -AdminAddress $using:ExistingControllerName -ErrorAction SilentlyContinue;
+                $xdSite = Get-XDSite -AdminAddress $ExistingControllerName -ErrorAction SilentlyContinue;
             }
             catch { } # Get-XDSite doesn't support $ErrorActionPreference :@
 
@@ -189,7 +188,8 @@ function TestXDSite {
             ScriptBlock = $scriptBlock;
             ErrorAction = 'Stop';
         }
-
+        ##Removed because we do not need CredSSP authentication in v5.
+        <#
         if ($null -ne $Credential) {
 
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
@@ -198,10 +198,10 @@ function TestXDSite {
 
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
         }
-
+        #>
         Write-Verbose $localizedData.InvokingScriptBlock;
 
-        return Invoke-Command @invokeCommandParams;
+        & $scriptBlock
 
     } #end process
 } #end function TestXDSite

--- a/DSCResources/VE_XD7WaitForSite/VE_XD7WaitForSite.psm1
+++ b/DSCResources/VE_XD7WaitForSite/VE_XD7WaitForSite.psm1
@@ -1,4 +1,5 @@
 Import-LocalizedData -BindingVariable localizedData -FileName VE_XD7WaitForSite.Resources.psd1;
+
 function Get-TargetResource {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
@@ -176,7 +177,7 @@ function TestXDSite {
             Import-Module 'C:\Program Files\Citrix\XenDesktopPoshSdk\Module\Citrix.XenDesktop.Admin.V1\Citrix.XenDesktop.Admin\Citrix.XenDesktop.Admin.psd1';
             try {
 
-                $xdSite = Get-XDSite -AdminAddress $ExistingControllerName -ErrorAction SilentlyContinue;
+                $xdSite = Get-XDSite -AdminAddress $using:ExistingControllerName -ErrorAction SilentlyContinue;
             }
             catch { } # Get-XDSite doesn't support $ErrorActionPreference :@
 
@@ -188,20 +189,18 @@ function TestXDSite {
             ScriptBlock = $scriptBlock;
             ErrorAction = 'Stop';
         }
-                
-        if ($null -ne $Credential) {
 
+        if ($null -ne $Credential) {
             AddInvokeScriptBlockCredentials -Hashtable $invokeCommandParams -Credential $Credential;
+            Write-Verbose $localizedData.InvokingScriptBlock;
+            return Invoke-Command @invokeCommandParams;
         }
         else {
-
             $invokeCommandParams['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($scriptBlock.ToString().Replace('$using:','$'));
+            Write-Verbose $localizedData.InvokingScriptBlock;
+            return & $invokeCommandParams.ScriptBlock
         }
         
-        Write-Verbose $localizedData.InvokingScriptBlock;
-
-        & $scriptBlock
-
     } #end process
 } #end function TestXDSite
 


### PR DESCRIPTION
Shift the return of invoke-command scriptblock up into if credential. If no credential, replace $using: as before, but execute with the call operator. If psdscrunascredentials are provided, they will be used. If not, system.