### PR TITLE
Releasing 2.8.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,26 @@
 
 ## Versions ##
 
+### 2.8.0 (2019-07-19)
+
+**BREAKING CHANGE** Makes '_FarmName_' property in XD7StoreFrontStore resource mandatory
+
+* Features
+  * Added new XD7StoreFrontAccountSelfService resource (via @BrianMcLain)
+  * Added new XD7StoreFrontAuthenticationService resource (via @BrianMcLain)
+  * Added new XD7StoreFrontPNA resource (via @BrianMcLain)
+  * Added new XD7StoreFrontRoamingBeacon resource (via @BrianMcLain)
+  * Added new XD7StoreFrontStoreFarm resource (via @BrianMcLain)
+  * Added new XD7StoreFrontWebReceiverResourcesService resource (via @BrianMcLain)
+  * Added new XD7StoreFrontWebReceiverSiteStyle resource (via @BrianMcLain)
+
+* Improvements
+  * Permits assigning multiple NetScaler gateways in StoreFrontRegisterStoreGateway resource
+
+* Bug Fixes
+  * Fixes bug in XD7StoreFrontFarmConfiguration when '_PooledSockets_' is specified
+  * Fixed bug in XD7StoreFrontRoamingGateway updating gateway that was not present
+
 ### 2.7.1 (2019-04-13) ###
 
 * Features
@@ -13,7 +33,6 @@
 
 * Bug fixes
   * Fixes Get-STFStoreFarm errors
-  * Ensures XD7StoreFrontRoamingGateway 'GatewayUrl' ends with a '/'
 
 ### 2.7.0 (2019-04-01) ###
 

--- a/Tests/Linting/FileEncoding.Tests.ps1
+++ b/Tests/Linting/FileEncoding.Tests.ps1
@@ -45,40 +45,4 @@ Describe 'Linting\FileEncoding' {
             TestEncodingPath -Path $_.FullName -Exclude $excludedPaths
         }
 
-    # $excludedPaths = @(
-    #                     '.git*',
-    #                     '.vscode',
-    #                     'DSCResources', # We'll take the public DSC resources as-is
-    #                     'Release',
-    #                     '*.png',
-    #                     'TestResults.xml'
-    #                 );
-
-    # Get-ChildItem -Path $repoRoot -Exclude $excludedPaths |
-    #     ForEach-Object {
-    #         Get-ChildItem -Path $_.FullName -Recurse |
-    #             ForEach-Object {
-
-    #                 if ($_ -is [System.IO.FileInfo])
-    #                 {
-    #                     It "File '$($_.FullName.Replace($repoRoot,''))' uses UTF-8 (no BOM) encoding" {
-    #                         $encoding = (Get-FileEncoding -Path $_.FullName -WarningAction SilentlyContinue).HeaderName
-    #                         $encoding | Should Be 'us-ascii'
-    #                     }
-    #                 }
-    #                 elseif ($_ -is [System.IO.DirectoryInfo])
-    #                 {
-    #                     TestEncodingPath -Path $_.FullName -Exclude $Exclude
-    #                 }
-
-    #                 ## Resolve-ProgramFilesFolder.ps1 contains Unicode characters
-    #                 if (($_ -is [System.IO.FileInfo]) -and ($_.Name -ne 'Resolve-ProgramFilesFolder.ps1'))
-    #                 {
-    #                     It "File '$($_.FullName.Replace($repoRoot,''))' uses UTF-8 (no BOM) encoding" {
-    #                         $encoding = (Get-FileEncoding -Path $_.FullName -WarningAction SilentlyContinue).HeaderName
-    #                         $encoding | Should Be 'us-ascii'
-    #                     }
-    #                 }
-    #             }
-    #     }
 }

--- a/XenDesktop7.psd1
+++ b/XenDesktop7.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion        = '2.7.1';
+    ModuleVersion        = '2.8.0';
     GUID                 = '3bacd95f-494b-4ea2-989b-09cb5e324940';
     Author               = 'Iain Brighton';
     CompanyName          = 'Virtual Engine';


### PR DESCRIPTION
**BREAKING CHANGE** Makes '_FarmName_' property in XD7StoreFrontStore resource mandatory

* Features
  * Added new XD7StoreFrontAccountSelfService resource (via @BrianMcLain)
  * Added new XD7StoreFrontAuthenticationService resource (via @BrianMcLain)
  * Added new XD7StoreFrontPNA resource (via @BrianMcLain)
  * Added new XD7StoreFrontRoamingBeacon resource (via @BrianMcLain)
  * Added new XD7StoreFrontStoreFarm resource (via @BrianMcLain)
  * Added new XD7StoreFrontWebReceiverResourcesService resource (via @BrianMcLain)
  * Added new XD7StoreFrontWebReceiverSiteStyle resource (via @BrianMcLain)

* Improvements
  * Permits assigning multiple NetScaler gateways in StoreFrontRegisterStoreGateway resource

* Bug Fixes
  * Fixes bug in XD7StoreFrontFarmConfiguration when '_PooledSockets_' is specified
  * Fixed bug in XD7StoreFrontRoamingGateway updating gateway that was not present