### PR TITLE
add xml parsing for missing setting values

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## Versions ##
 
+### 2.8.1 (2019-07-26)
+
+* Bug Fixes
+  * Fix bug in XD7StoreFrontFarmConfiguration where PooledSocket and ServerCommunicationAttempts were returning incorrect values
+
 ### 2.8.0 (2019-07-19)
 
 **BREAKING CHANGE** Makes '_FarmName_' property in XD7StoreFrontStore resource mandatory

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Versions ##
 
-### 2.8.1 (2019-07-26)
+### Unreleased
 
 * Bug Fixes
   * Fix bug in XD7StoreFrontFarmConfiguration where PooledSocket and ServerCommunicationAttempts were returning incorrect values

--- a/DSCResources/VE_XD7StoreFrontFarmConfiguration/VE_XD7StoreFrontFarmConfiguration.psm1
+++ b/DSCResources/VE_XD7StoreFrontFarmConfiguration/VE_XD7StoreFrontFarmConfiguration.psm1
@@ -33,7 +33,7 @@ function Get-TargetResource
         ## This is a hack, as Get-STFStoreFarm throws an error if run twice in quick succession?!
         $null = Get-STFStoreFarm -StoreService $StoreService -Verbose -OutVariable Configuration
         # XML contains some data points that we cannot obtain using the cmdlet
-        $storeSettings = [xml]$(Get-Content $StoreService.ConfigurationFile).configuration.'citrix.deliveryservices'.wing.farmsets.farmset
+        $storeSettings = $([xml]$(Get-Content $StoreService.ConfigurationFile)).configuration.'citrix.deliveryservices'.wing.farmsets.farmset
     }
     catch {
 

--- a/DSCResources/VE_XD7StoreFrontFarmConfiguration/VE_XD7StoreFrontFarmConfiguration.psm1
+++ b/DSCResources/VE_XD7StoreFrontFarmConfiguration/VE_XD7StoreFrontFarmConfiguration.psm1
@@ -32,6 +32,8 @@ function Get-TargetResource
         Write-Verbose -Message $localizedData.CallingGetSTFStoreFarmConfiguration
         ## This is a hack, as Get-STFStoreFarm throws an error if run twice in quick succession?!
         $null = Get-STFStoreFarm -StoreService $StoreService -Verbose -OutVariable Configuration
+        # XML contains some data points that we cannot obtain using the cmdlet
+        $storeSettings = [xml]$(Get-Content $StoreService.ConfigurationFile).configuration.'citrix.deliveryservices'.wing.farmsets.farmset
     }
     catch {
 
@@ -46,9 +48,8 @@ function Get-TargetResource
         LeasingStatusExpiryFailed = [System.String]$Configuration.LeasingStatusExpiryFailed
         LeasingStatusExpiryLeasing = [System.String]$Configuration.LeasingStatusExpiryLeasing
         LeasingStatusExpiryPending = [System.String]$Configuration.LeasingStatusExpiryPending
-        #PooledSockets does not actually show up with the Get, so if you change this, it will always do the Set.
-        PooledSockets = [System.Boolean]$Configuration.PooledSockets
-        ServerCommunicationAttempts = [System.UInt32]$Configuration.ServerCommunicationAttempts
+        PooledSockets = [System.Boolean]$($storeSettings.pooledSockets -eq "on")
+        ServerCommunicationAttempts = [System.UInt32]$storeSettings.serverCommunicationAttempts
         BackgroundHealthCheckPollingPeriod = [System.String]$Configuration.BackgroundHealthCheckPollingPeriod
         AdvancedHealthCheck = [System.Boolean]$Configuration.AdvancedHealthCheck
     }

--- a/XenDesktop7.psd1
+++ b/XenDesktop7.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion        = '2.8.1';
+    ModuleVersion        = '2.8.0';
     GUID                 = '3bacd95f-494b-4ea2-989b-09cb5e324940';
     Author               = 'Iain Brighton';
     CompanyName          = 'Virtual Engine';

--- a/XenDesktop7.psd1
+++ b/XenDesktop7.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion        = '2.8.0';
+    ModuleVersion        = '2.8.1';
     GUID                 = '3bacd95f-494b-4ea2-989b-09cb5e324940';
     Author               = 'Iain Brighton';
     CompanyName          = 'Virtual Engine';


### PR DESCRIPTION
This change adds parsing for the store's web.config XML to obtain some missing setting values ( Boolean PooledSockets and Integer ServerCommunicationAttempts ) in the Get-TargetResource method within XD7StoreFrontFarmConfiguration