### PR TITLE
Corrected string format bug

### DIFF
--- a/DSCResources/VE_XD7StoreFrontOptimalGateway/VE_XD7StoreFrontOptimalGateway.psm1
+++ b/DSCResources/VE_XD7StoreFrontOptimalGateway/VE_XD7StoreFrontOptimalGateway.psm1
@@ -213,10 +213,10 @@ function Set-TargetResource
             }
             if (!($PSBoundParameters.ContainsKey('Zones'))) {
                 $Zones = [System.String[]]$Gateway.Zones
-                Write-Verbose -Message ($localizedData.SettingZones -f $Zones)
+                Write-Verbose -Message ($localizedData.SettingZones -f ($Zones -join ','))
             }
             else {
-                Write-Verbose -Message ($localizedData.UpdatingZones -f $Zones)
+                Write-Verbose -Message ($localizedData.UpdatingZones -f ($Zones -join ','))
             }
             if (!($PSBoundParameters.ContainsKey('EnabledOnDirectAccess'))) {
                 $EnabledOnDirectAccess = [System.Boolean]$Gateway.EnabledOnDirectAccess


### PR DESCRIPTION
When $Zones is an empy array, string format call throws exception.  Converting to string.