### PR TITLE
Fixed a typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1403,14 +1403,6 @@ Creates or sets a StoreFront store and all it's properties.
 ### Syntax
 
 ```
-
-## XD7StoreFrontStore
-
-Creates or sets a StoreFront store and all it's properties.
-
-### Syntax
-
-```
 VE_XD7StoreFrontStore [string]
 {
     StoreName = [String]


### PR DESCRIPTION
A typo creeped up into the README that messed up the formatting of subsequent sections.