### PR TITLE
Releasing 2.10.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## Versions ##
 
+### 2.10.2 (2023-11-04)
+
+* Bug Fixes
+  * Fixes 'XD7StoreFrontRoamingGateway\Test-TargetResource' failing when StaUrl configured (#60)
+
 ### 2.10.1 (2023-11-01)
 
 * Bug Fixes

--- a/DSCResources/VE_XD7StoreFrontRoamingGateway/VE_XD7StoreFrontRoamingGateway.psm1
+++ b/DSCResources/VE_XD7StoreFrontRoamingGateway/VE_XD7StoreFrontRoamingGateway.psm1
@@ -53,7 +53,7 @@ function Get-TargetResource
 		SessionReliability = [System.Boolean]$Gateway.SessionReliability
 		RequestTicketTwoSTAs = [System.Boolean]$Gateway.RequestTicketTwoStas
 		SubnetIPAddress = [System.String]$Gateway.IpAddress
-		SecureTicketAuthorityUrls = [System.String[]]$Gateway.SecureTicketAuthorityUrls
+		SecureTicketAuthorityUrls = [System.String[]]$Gateway.SecureTicketAuthorityUrls.StaUrl
 		StasUseLoadBalancing = [System.Boolean]$Gateway.StasUseLoadBalancing
 		StasBypassDuration = [System.String]$Gateway.StasBypassDuration
 		GslbUrl = [System.String]$Gateway.GslbLocation

--- a/XenDesktop7.psd1
+++ b/XenDesktop7.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion        = '2.10.1';
+    ModuleVersion        = '2.10.2';
     GUID                 = '3bacd95f-494b-4ea2-989b-09cb5e324940';
     Author               = 'Iain Brighton';
     CompanyName          = 'Virtual Engine';


### PR DESCRIPTION
* Bug Fixes
  * Fixes 'XD7StoreFrontRoamingGateway\Test-TargetResource' failing when StaUrl configured (#60)
